### PR TITLE
Support ffmpeg pipe: protocol

### DIFF
--- a/fio/fio.c
+++ b/fio/fio.c
@@ -831,6 +831,17 @@ static fio_vfd_t *vfd_get(int fd) {
     return &fio_state.vfds[idx];
 }
 
+/* Real kernel fds (stdio, dup'd stdio, fd: protocol, etc.) live below
+ * FIO_VFD_BASE. Virtual fds returned by fio_open start at FIO_VFD_BASE.
+ * Anything below that range didn't come from our tunnel — ffmpeg got it
+ * from the kernel (pipe: protocol dups stdin/stdout into a fresh fd; fd:
+ * takes an fd directly), so read/write/seek/close/fstat on it must go to
+ * real syscalls. Server-side Go plumbing already forwards stdio to/from
+ * the client (MsgStdin/MsgStdout/MsgStderr). */
+static inline int is_real_fd(int fd) {
+    return fd >= 0 && fd < FIO_VFD_BASE;
+}
+
 static void vfd_free(int fd) {
     if (fd < FIO_VFD_BASE || fd >= FIO_VFD_BASE + FIO_MAX_FILES) return;
     fio_state.vfds[fd - FIO_VFD_BASE].active = 0;
@@ -980,7 +991,7 @@ int fio_open(const char *path, int flags, mode_t mode) {
 ssize_t fio_read(int fd, void *buf, size_t count) {
     fio_ensure_init();
 
-    if (fio_state.initialized == 1) {
+    if (fio_state.initialized == 1 || is_real_fd(fd)) {
         return read(fd, buf, count);
     }
 
@@ -1029,7 +1040,7 @@ ssize_t fio_read(int fd, void *buf, size_t count) {
 ssize_t fio_write(int fd, const void *buf, size_t count) {
     fio_ensure_init();
 
-    if (fio_state.initialized == 1) {
+    if (fio_state.initialized == 1 || is_real_fd(fd)) {
         return write(fd, buf, count);
     }
 
@@ -1080,7 +1091,7 @@ ssize_t fio_write(int fd, const void *buf, size_t count) {
 off_t fio_lseek(int fd, off_t offset, int whence) {
     fio_ensure_init();
 
-    if (fio_state.initialized == 1) {
+    if (fio_state.initialized == 1 || is_real_fd(fd)) {
 #ifdef _WIN32
         return _lseeki64(fd, offset, whence);
 #else
@@ -1138,7 +1149,7 @@ off_t fio_lseek(int fd, off_t offset, int whence) {
 int fio_close(int fd) {
     fio_ensure_init();
 
-    if (fio_state.initialized == 1) {
+    if (fio_state.initialized == 1 || is_real_fd(fd)) {
         return close(fd);
     }
 
@@ -1174,7 +1185,7 @@ int fio_close(int fd) {
 int fio_fstat(int fd, struct stat *st) {
     fio_ensure_init();
 
-    if (fio_state.initialized == 1) {
+    if (fio_state.initialized == 1 || is_real_fd(fd)) {
         return fstat(fd, st);
     }
 
@@ -1234,7 +1245,7 @@ int fio_fstat(int fd, struct stat *st) {
 int fio_ftruncate(int fd, off_t length) {
     fio_ensure_init();
 
-    if (fio_state.initialized == 1) {
+    if (fio_state.initialized == 1 || is_real_fd(fd)) {
 #ifdef _WIN32
         return _chsize_s(fd, length) == 0 ? 0 : -1;
 #else

--- a/tests/integration/test-pipe-protocol.sh
+++ b/tests/integration/test-pipe-protocol.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test for https://github.com/steelbrain/ffmpeg-over-ip/issues/8
+#
+# ffmpeg's pipe: protocol (pipe:0 / pipe:1 / pipe:2) is broken under
+# ffmpeg-over-ip: the patched ffmpeg's file.c stores fd 0/1/2 directly in
+# c->fd, then file_read / file_write call fio_read / fio_write with those
+# raw stdio fds. In tunneled mode the fio layer rejects any fd below
+# FIO_VFD_BASE (10000) with EBADF, surfacing as "Bad file descriptor".
+#
+# The Go side already forwards client stdin -> server -> ffmpeg.Stdin and
+# ffmpeg.Stdout -> server -> client stdout, so once fio passes through stdio
+# fds, pipe: just works end-to-end.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+FFMPEG="$ROOT/build/ffmpeg/bin/ffmpeg"
+
+echo "=== test-pipe-protocol: ffmpeg pipe: protocol over ffmpeg-over-ip ==="
+
+[ -x "$FFMPEG" ] || { echo "Patched ffmpeg not found. Run: bash scripts/build-ffmpeg.sh --minimal"; exit 1; }
+
+TMPDIR_TEST=$(mktemp -d)
+trap 'kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null; rm -rf $TMPDIR_TEST' EXIT
+
+echo "Building server and client..."
+BIN_DIR="$TMPDIR_TEST/bin"
+mkdir -p "$BIN_DIR"
+go build -o "$BIN_DIR/ffmpeg-over-ip-server" ./cmd/server
+go build -o "$BIN_DIR/ffmpeg-over-ip-client" ./cmd/client
+ln -sf "$FFMPEG" "$BIN_DIR/ffmpeg"
+ln -sf "$ROOT/build/ffmpeg/bin/ffprobe" "$BIN_DIR/ffprobe"
+
+PORT=$((20000 + RANDOM % 10000))
+
+cat > "$TMPDIR_TEST/server.jsonc" << CONF
+{
+  "address": "127.0.0.1:$PORT",
+  "authSecret": "test-secret-key"
+}
+CONF
+
+cat > "$TMPDIR_TEST/client.jsonc" << CONF
+{
+  "address": "127.0.0.1:$PORT",
+  "authSecret": "test-secret-key"
+}
+CONF
+
+"$BIN_DIR/ffmpeg-over-ip-server" --config "$TMPDIR_TEST/server.jsonc" &
+SERVER_PID=$!
+sleep 0.5
+
+if ! kill -0 $SERVER_PID 2>/dev/null; then
+    echo "FAIL: server did not start"
+    exit 1
+fi
+echo "Server running on port $PORT (PID $SERVER_PID)"
+
+# Reference input: 5 frames of YUV420p 64x64 = 5 * 64*64*3/2 = 30720 bytes
+INPUT="$TMPDIR_TEST/input.raw"
+"$FFMPEG" -f lavfi -i "color=c=green:s=64x64:d=1:r=5" \
+    -f rawvideo "$INPUT" -y 2>/dev/null
+INPUT_SIZE=$(wc -c < "$INPUT" | tr -d ' ')
+echo "Reference input: $INPUT_SIZE bytes"
+
+# --- Test 1: pipe:1 (write output to client stdout) ---
+echo ""
+echo "--- Test 1: file input -> pipe:1 (client stdout) ---"
+OUTPUT1="$TMPDIR_TEST/pipe1_output.raw"
+
+set +e
+FFMPEG_OVER_IP_CLIENT_CONFIG="$TMPDIR_TEST/client.jsonc" \
+    "$BIN_DIR/ffmpeg-over-ip-client" \
+    -hide_banner -v error \
+    -f rawvideo -video_size 64x64 -pix_fmt yuv420p \
+    -i "$INPUT" \
+    -f rawvideo pipe:1 \
+    > "$OUTPUT1" 2> "$TMPDIR_TEST/pipe1.err"
+EXIT1=$?
+set -e
+
+if [ "$EXIT1" -ne 0 ]; then
+    echo "FAIL: client exited with $EXIT1"
+    echo "--- stderr ---"
+    cat "$TMPDIR_TEST/pipe1.err"
+    exit 1
+fi
+
+if ! cmp -s "$INPUT" "$OUTPUT1"; then
+    echo "FAIL: pipe:1 output does not match input"
+    echo "  input:  $(wc -c < "$INPUT" | tr -d ' ') bytes"
+    echo "  output: $(wc -c < "$OUTPUT1" | tr -d ' ') bytes"
+    echo "--- stderr ---"
+    cat "$TMPDIR_TEST/pipe1.err"
+    exit 1
+fi
+echo "PASS: pipe:1 output matches input byte-for-byte"
+
+# --- Test 2: pipe:0 (read input from client stdin) ---
+echo ""
+echo "--- Test 2: pipe:0 (client stdin) -> file output ---"
+OUTPUT2="$TMPDIR_TEST/pipe0_output.raw"
+
+set +e
+FFMPEG_OVER_IP_CLIENT_CONFIG="$TMPDIR_TEST/client.jsonc" \
+    "$BIN_DIR/ffmpeg-over-ip-client" \
+    -hide_banner -v error \
+    -f rawvideo -video_size 64x64 -pix_fmt yuv420p \
+    -i pipe:0 \
+    -f rawvideo "$OUTPUT2" -y \
+    < "$INPUT" 2> "$TMPDIR_TEST/pipe0.err"
+EXIT2=$?
+set -e
+
+if [ "$EXIT2" -ne 0 ]; then
+    echo "FAIL: client exited with $EXIT2"
+    echo "--- stderr ---"
+    cat "$TMPDIR_TEST/pipe0.err"
+    exit 1
+fi
+
+if ! cmp -s "$INPUT" "$OUTPUT2"; then
+    echo "FAIL: pipe:0 output does not match input"
+    echo "  input:  $(wc -c < "$INPUT" | tr -d ' ') bytes"
+    echo "  output: $(wc -c < "$OUTPUT2" | tr -d ' ') bytes"
+    echo "--- stderr ---"
+    cat "$TMPDIR_TEST/pipe0.err"
+    exit 1
+fi
+echo "PASS: pipe:0 input transcoded byte-for-byte"
+
+# --- Test 3: pipe:0 -> pipe:1 (full passthrough via stdio) ---
+echo ""
+echo "--- Test 3: pipe:0 -> pipe:1 (stdin -> stdout passthrough) ---"
+OUTPUT3="$TMPDIR_TEST/pipe_both_output.raw"
+
+set +e
+FFMPEG_OVER_IP_CLIENT_CONFIG="$TMPDIR_TEST/client.jsonc" \
+    "$BIN_DIR/ffmpeg-over-ip-client" \
+    -hide_banner -v error \
+    -f rawvideo -video_size 64x64 -pix_fmt yuv420p \
+    -i pipe:0 \
+    -f rawvideo pipe:1 \
+    < "$INPUT" > "$OUTPUT3" 2> "$TMPDIR_TEST/pipe_both.err"
+EXIT3=$?
+set -e
+
+if [ "$EXIT3" -ne 0 ]; then
+    echo "FAIL: client exited with $EXIT3"
+    echo "--- stderr ---"
+    cat "$TMPDIR_TEST/pipe_both.err"
+    exit 1
+fi
+
+if ! cmp -s "$INPUT" "$OUTPUT3"; then
+    echo "FAIL: pipe:0 -> pipe:1 output does not match input"
+    echo "  input:  $(wc -c < "$INPUT" | tr -d ' ') bytes"
+    echo "  output: $(wc -c < "$OUTPUT3" | tr -d ' ') bytes"
+    echo "--- stderr ---"
+    cat "$TMPDIR_TEST/pipe_both.err"
+    exit 1
+fi
+echo "PASS: pipe:0 -> pipe:1 passthrough matches byte-for-byte"
+
+echo ""
+echo "test-pipe-protocol: ALL PASSED"


### PR DESCRIPTION
## Summary
- Fixes #8 — `ffmpeg -i pipe:0` and `-f ... pipe:1` failed under ffmpeg-over-ip with muxer errors like *"Error submitting a packet to the muxer: Bad file descriptor"*.
- Root cause: ffmpeg's `pipe:` URL protocol calls `fd_dup()` on the inherited stdio fd, then routes read/write/close/seek/fstat through the patched `file_*` ops which call `fio_*`. In tunneled mode, fio rejected any fd below `FIO_VFD_BASE` (10000) with `EBADF`.
- Fix: treat any fd `< FIO_VFD_BASE` as a real kernel fd and passthrough the syscall. The server-side Go plumbing already forwards the child's stdio to the client (`MsgStdin` / `MsgStdout` / `MsgStderr`), so once fio gets out of the way the bytes flow through transparently. Also fixes the `fd:` protocol and any future code path that hands raw OS fds to fio.

## Test plan
- [x] Added `tests/integration/test-pipe-protocol.sh` covering all three pipe modes:
  - file input → `pipe:1` (client stdout)
  - `pipe:0` (client stdin) → file output
  - `pipe:0` → `pipe:1` (stdin → stdout passthrough)
  Each case transcodes 5 YUV420p 64×64 frames and verifies byte-for-byte match.
- [x] All 65 fio C unit tests still pass (`make -C fio test`).
- [x] All Go unit tests still pass (`go test ./internal/... -race`).
- [x] Reproduced the original failure on `main`, confirmed it now passes.