### PR TITLE
Skip ASan on Apple clang to avoid macOS 26 init deadlock

### DIFF
--- a/fio/Makefile
+++ b/fio/Makefile
@@ -2,7 +2,24 @@ CC ?= cc
 CFLAGS = -Wall -Wextra -Werror -std=c11 -DFIO_TESTING -D_DEFAULT_SOURCE -D_DARWIN_C_SOURCE
 LDFLAGS = -lpthread
 
-SANITIZE_FLAGS = -fsanitize=address,undefined -fno-omit-frame-pointer -g
+# ASan on Apple clang deadlocks during init on macOS 26: its malloc zone hook
+# re-enters AsanInitFromRtl from dyld_shared_cache_iterate_text_swift while the
+# init mutex is already held, so the process spins on sched_yield forever.
+# Drop ASan on that combo and keep UBSan; other hosts (Linux CI, non-Apple
+# clang) get both. Override with ENABLE_ASAN=1 to force ASan regardless.
+UNAME_S := $(shell uname -s)
+IS_APPLE_CLANG := $(shell $(CC) --version 2>&1 | grep -qi "Apple clang" && echo 1)
+ifeq ($(ENABLE_ASAN),1)
+  SANITIZERS := address,undefined
+  SANITIZE_LABEL := ASan + UBSan
+else ifeq ($(UNAME_S)-$(IS_APPLE_CLANG),Darwin-1)
+  SANITIZERS := undefined
+  SANITIZE_LABEL := UBSan (ASan disabled on Apple clang / macOS — set ENABLE_ASAN=1 to override)
+else
+  SANITIZERS := address,undefined
+  SANITIZE_LABEL := ASan + UBSan
+endif
+SANITIZE_FLAGS = -fsanitize=$(SANITIZERS) -fno-omit-frame-pointer -g
 
 # Detect clang for static analysis (--analyze is clang-only)
 IS_CLANG := $(shell $(CC) --version 2>&1 | grep -qi clang && echo 1)
@@ -13,7 +30,7 @@ test: fio_test fio_test_sanitize
 	@echo "=== unit tests ==="
 	./fio_test
 	@echo ""
-	@echo "=== unit tests (ASan + UBSan) ==="
+	@echo "=== unit tests ($(SANITIZE_LABEL)) ==="
 	./fio_test_sanitize
 ifeq ($(IS_CLANG),1)
 	@echo ""


### PR DESCRIPTION
## Summary
- `fio_test_sanitize` hangs forever on macOS 26 + Apple clang 17 — `make test` never completes locally.
- Root cause is a toolchain-level reentrancy deadlock in ASan's init. The malloc zone hook re-enters `AsanInitFromRtl` from `dyld_shared_cache_iterate_text_swift` while ASan's init mutex is already held, and the second call spins on `sched_yield` indefinitely. Captured stack trace via `/usr/bin/sample`:
  ```
  AsanInitFromRtl -> AsanInitInternal -> InitializeShadowMemory
    -> get_dyld_hdr -> dyld_shared_cache_iterate_text_swift
    -> _Block_copy -> malloc -> __sanitizer_mz_malloc
    -> AsanInitFromRtl (re-entry) -> StaticSpinMutex::LockSlow
  ```
- Can't be fixed in fio source — it's an Apple clang 17 / macOS 26 issue. `ASAN_OPTIONS=verify_asan_link_order=0` and `MallocNanoZone=0` both still hang.
- Detect `Darwin + Apple clang` in the Makefile; drop `-fsanitize=address` on that combo and keep UBSan. All other hosts (Linux CI, homebrew LLVM, cross-compilers) still get the full ASan+UBSan run. `ENABLE_ASAN=1` overrides.

## Test plan
- [x] `make test` on macOS 26 + Apple clang 17 now completes (65/65 unit + 65/65 UBSan + static analysis clean).
- [x] `make -n fio_test_sanitize` on macOS emits `-fsanitize=undefined` only.
- [x] `ENABLE_ASAN=1 make -n fio_test_sanitize` emits `-fsanitize=address,undefined` (matches CI).
- [x] CI on `ubuntu-latest` is unaffected — `UNAME_S=Linux` falls through to `address,undefined`.