### PR TITLE
Support configuration via individual environment variables

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,12 +2,54 @@
 
 Config files use [JSONC](https://code.visualstudio.com/docs/languages/json#_json-with-comments) format (JSON with `//` comments, `/* */` block comments, and trailing commas).
 
+## Config Resolution Order
+
+Configuration is resolved in this order (first match wins):
+
+1. **Explicit path** — `--config <path>` (server only)
+2. **Config file env var** — `FFMPEG_OVER_IP_SERVER_CONFIG` / `FFMPEG_OVER_IP_CLIENT_CONFIG` pointing to a file
+3. **Individual env vars** — if both `_ADDRESS` and `_AUTH_SECRET` are set (see [Environment Variables](#environment-variables) below)
+4. **File search** — standard paths (see below)
+
+## Environment Variables
+
+If both `ADDRESS` and `AUTH_SECRET` env vars are set (and no `_CONFIG` env var is set), configuration is read entirely from environment variables — no config file is needed.
+
+### Client
+
+| Variable | Required | Description |
+|---|---|---|
+| `FFMPEG_OVER_IP_CLIENT_ADDRESS` | Yes | Server address (`host:port` or `unix:/path`) |
+| `FFMPEG_OVER_IP_CLIENT_AUTH_SECRET` | Yes | HMAC auth secret (must match server) |
+| `FFMPEG_OVER_IP_CLIENT_LOG` | No | Log destination: `stdout`, `stderr`, or file path |
+
+### Server
+
+| Variable | Required | Description |
+|---|---|---|
+| `FFMPEG_OVER_IP_SERVER_ADDRESS` | Yes | Listen address (`host:port` or `unix:/path`) |
+| `FFMPEG_OVER_IP_SERVER_AUTH_SECRET` | Yes | HMAC auth secret (must match client) |
+| `FFMPEG_OVER_IP_SERVER_LOG` | No | Log destination: `stdout`, `stderr`, or file path |
+| `FFMPEG_OVER_IP_SERVER_DEBUG` | No | Log original/rewritten args (`true`, `1`, `yes`, `y`) |
+
+Rewrites are not supported via environment variables — use a config file if you need them.
+
+### Example (Docker / scripted deployment)
+
+```bash
+docker run \
+  -e FFMPEG_OVER_IP_CLIENT_ADDRESS=192.168.1.100:5050 \
+  -e FFMPEG_OVER_IP_CLIENT_AUTH_SECRET=my-secret \
+  -v ./ffmpeg-over-ip-client:/usr/bin/ffmpeg \
+  your-image
+```
+
 ## Config File Search Paths
 
-Config is loaded from the first file found (in order):
+If no explicit path or env var config is used, the first file found wins:
 
-1. `FFMPEG_OVER_IP_SERVER_CONFIG` / `FFMPEG_OVER_IP_CLIENT_CONFIG` env var
-2. Next to the binary: `<exe-dir>/ffmpeg-over-ip.{server,client}.jsonc`
+1. Next to the binary: `<exe-dir>/ffmpeg-over-ip.{server,client}.jsonc`
+2. Next to the binary (hidden): `<exe-dir>/.ffmpeg-over-ip.{server,client}.jsonc`
 3. `./ffmpeg-over-ip.{server,client}.jsonc`
 4. `./.ffmpeg-over-ip.{server,client}.jsonc`
 5. `~/.ffmpeg-over-ip.{server,client}.jsonc`

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,36 +1,41 @@
 # Docker Integration
 
-You can use ffmpeg-over-ip in Docker environments by mounting the binary and configuration as volumes. This allows containers to use ffmpeg remotely without needing GPU passthrough or other special setup.
+You can use ffmpeg-over-ip in Docker environments by mounting the binary and passing configuration via environment variables. This allows containers to use ffmpeg remotely without needing GPU passthrough or other special setup.
 
 ## Client in Docker
 
-Mount the client binary as `/usr/bin/ffmpeg` so your app uses it transparently:
+Mount the client binary as `/usr/bin/ffmpeg` and pass config via environment variables:
 
 ```bash
 docker run \
+  -e FFMPEG_OVER_IP_CLIENT_ADDRESS=192.168.1.100:5050 \
+  -e FFMPEG_OVER_IP_CLIENT_AUTH_SECRET=your-secret \
   -v ./ffmpeg-over-ip-client:/usr/bin/ffmpeg \
-  -v ./ffmpeg-over-ip.client.jsonc:/etc/ffmpeg-over-ip.client.jsonc \
   your-image
 ```
 
-For ffprobe support, add a symlink or a second mount:
+For ffprobe support, add a second mount:
 
 ```bash
 docker run \
+  -e FFMPEG_OVER_IP_CLIENT_ADDRESS=192.168.1.100:5050 \
+  -e FFMPEG_OVER_IP_CLIENT_AUTH_SECRET=your-secret \
   -v ./ffmpeg-over-ip-client:/usr/bin/ffmpeg \
   -v ./ffmpeg-over-ip-client:/usr/bin/ffprobe \
-  -v ./ffmpeg-over-ip.client.jsonc:/etc/ffmpeg-over-ip.client.jsonc \
   your-image
 ```
+
+You can also use a config file volume instead of env vars — see [Configuration](configuration.md) for details.
 
 ## Server in Docker
 
 ```bash
 docker run \
+  -e FFMPEG_OVER_IP_SERVER_ADDRESS=0.0.0.0:5050 \
+  -e FFMPEG_OVER_IP_SERVER_AUTH_SECRET=your-secret \
   -v ./ffmpeg-over-ip-server:/usr/bin/ffmpeg-over-ip-server \
   -v ./ffmpeg:/usr/bin/ffmpeg \
   -v ./ffprobe:/usr/bin/ffprobe \
-  -v ./ffmpeg-over-ip.server.jsonc:/etc/ffmpeg-over-ip.server.jsonc \
   --runtime=nvidia \
   your-image
 ```
@@ -41,56 +46,51 @@ All three binaries (`ffmpeg-over-ip-server`, `ffmpeg`, `ffprobe`) must be in the
 
 If the server and client run on the same machine (e.g., server on the host, client in a container), use a Unix socket instead of TCP to avoid network overhead and `host.docker.internal` configuration:
 
-Server config:
-```jsonc
-{
-  "address": "unix:/tmp/ffmpeg-over-ip.sock",
-  "authSecret": "your-secret",
-}
-```
+Start the server with a socket address (config file or env var):
 
-Client config:
-```jsonc
-{
-  "address": "unix:/tmp/ffmpeg-over-ip.sock",
-  "authSecret": "your-secret",
-}
+```bash
+export FFMPEG_OVER_IP_SERVER_ADDRESS=unix:/tmp/ffmpeg-over-ip.sock
+export FFMPEG_OVER_IP_SERVER_AUTH_SECRET=your-secret
+./ffmpeg-over-ip-server
 ```
 
 Then mount the socket into the container:
 
 ```bash
 docker run \
+  -e FFMPEG_OVER_IP_CLIENT_ADDRESS=unix:/tmp/ffmpeg-over-ip.sock \
+  -e FFMPEG_OVER_IP_CLIENT_AUTH_SECRET=your-secret \
   -v /tmp/ffmpeg-over-ip.sock:/tmp/ffmpeg-over-ip.sock \
   -v ./ffmpeg-over-ip-client:/usr/bin/ffmpeg \
-  -v ./ffmpeg-over-ip.client.jsonc:/etc/ffmpeg-over-ip.client.jsonc \
   your-image
 ```
 
 ## Debugging
 
-Enable `debug` and `log` in the server config to see what commands are being executed and how rewrites are applied:
+Enable debug logging on the server via env vars:
 
-```jsonc
-{
-  "address": "0.0.0.0:5050",
-  "authSecret": "your-secret",
-  "log": "stdout",
-  "debug": true,
-  "rewrites": [
-    ["h264_nvenc", "h264_qsv"],
-  ],
-}
+```bash
+docker run \
+  -e FFMPEG_OVER_IP_SERVER_ADDRESS=0.0.0.0:5050 \
+  -e FFMPEG_OVER_IP_SERVER_AUTH_SECRET=your-secret \
+  -e FFMPEG_OVER_IP_SERVER_LOG=stdout \
+  -e FFMPEG_OVER_IP_SERVER_DEBUG=true \
+  -v ./ffmpeg-over-ip-server:/usr/bin/ffmpeg-over-ip-server \
+  -v ./ffmpeg:/usr/bin/ffmpeg \
+  -v ./ffprobe:/usr/bin/ffprobe \
+  --runtime=nvidia \
+  your-image
 ```
 
-For the client, set the log to a file you can tail from inside the container:
+For the client, log to a file you can tail from inside the container:
 
-```jsonc
-{
-  "address": "192.168.1.100:5050",
-  "authSecret": "your-secret",
-  "log": "/tmp/ffmpeg-over-ip.client.log",
-}
+```bash
+docker run \
+  -e FFMPEG_OVER_IP_CLIENT_ADDRESS=192.168.1.100:5050 \
+  -e FFMPEG_OVER_IP_CLIENT_AUTH_SECRET=your-secret \
+  -e FFMPEG_OVER_IP_CLIENT_LOG=/tmp/ffmpeg-over-ip.client.log \
+  -v ./ffmpeg-over-ip-client:/usr/bin/ffmpeg \
+  your-image
 ```
 
 Then tail it:
@@ -98,3 +98,5 @@ Then tail it:
 ```bash
 docker exec -it <container> tail -f /tmp/ffmpeg-over-ip.client.log
 ```
+
+Note: rewrites require a config file — they can't be set via env vars. If you need rewrites alongside env var config, use `FFMPEG_OVER_IP_SERVER_CONFIG` to point to a config file instead.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -60,3 +60,15 @@ Test the connection by running a command through the client:
 ```
 
 You should see the server's ffmpeg version and build info. If you get a connection error, double-check the address, port, and auth secret.
+
+## Alternative: Environment Variables
+
+Instead of config files, you can pass configuration via environment variables. This is useful for Docker and scripted deployments:
+
+```bash
+export FFMPEG_OVER_IP_SERVER_ADDRESS=0.0.0.0:5050
+export FFMPEG_OVER_IP_SERVER_AUTH_SECRET=pick-a-strong-secret
+./ffmpeg-over-ip-server
+```
+
+See [Configuration](configuration.md#environment-variables) for all supported variables.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,8 +44,16 @@ type ClientConfig struct {
 }
 
 // LoadServerConfig loads the server config. If explicitPath is non-empty, it
-// loads from that path directly. Otherwise it searches env var and standard paths.
+// loads from that path directly. Otherwise it checks env vars, then searches
+// standard paths.
 func LoadServerConfig(explicitPath string) (*ServerConfig, error) {
+	// If no explicit path and no _CONFIG env var, try individual env vars
+	if explicitPath == "" && os.Getenv("FFMPEG_OVER_IP_SERVER_CONFIG") == "" {
+		if cfg := serverConfigFromEnv(); cfg != nil {
+			return cfg, nil
+		}
+	}
+
 	data, err := loadConfigBytes(explicitPath, "server")
 	if err != nil {
 		return nil, err
@@ -64,8 +72,16 @@ func LoadServerConfig(explicitPath string) (*ServerConfig, error) {
 }
 
 // LoadClientConfig loads the client config. If explicitPath is non-empty, it
-// loads from that path directly. Otherwise it searches env var and standard paths.
+// loads from that path directly. Otherwise it checks env vars, then searches
+// standard paths.
 func LoadClientConfig(explicitPath string) (*ClientConfig, error) {
+	// If no explicit path and no _CONFIG env var, try individual env vars
+	if explicitPath == "" && os.Getenv("FFMPEG_OVER_IP_CLIENT_CONFIG") == "" {
+		if cfg := clientConfigFromEnv(); cfg != nil {
+			return cfg, nil
+		}
+	}
+
 	data, err := loadConfigBytes(explicitPath, "client")
 	if err != nil {
 		return nil, err
@@ -81,6 +97,48 @@ func LoadClientConfig(explicitPath string) (*ClientConfig, error) {
 		return nil, fmt.Errorf("config: authSecret is required")
 	}
 	return &cfg, nil
+}
+
+// serverConfigFromEnv builds a ServerConfig from individual environment variables.
+// Returns nil unless both ADDRESS and AUTH_SECRET are set.
+func serverConfigFromEnv() *ServerConfig {
+	address := os.Getenv("FFMPEG_OVER_IP_SERVER_ADDRESS")
+	authSecret := os.Getenv("FFMPEG_OVER_IP_SERVER_AUTH_SECRET")
+	if address == "" || authSecret == "" {
+		return nil
+	}
+	return &ServerConfig{
+		Address:    address,
+		AuthSecret: authSecret,
+		Log:        LogValue(os.Getenv("FFMPEG_OVER_IP_SERVER_LOG")),
+		Debug:      parseLaxBool(os.Getenv("FFMPEG_OVER_IP_SERVER_DEBUG")),
+	}
+}
+
+// clientConfigFromEnv builds a ClientConfig from individual environment variables.
+// Returns nil unless both ADDRESS and AUTH_SECRET are set.
+func clientConfigFromEnv() *ClientConfig {
+	address := os.Getenv("FFMPEG_OVER_IP_CLIENT_ADDRESS")
+	authSecret := os.Getenv("FFMPEG_OVER_IP_CLIENT_AUTH_SECRET")
+	if address == "" || authSecret == "" {
+		return nil
+	}
+	return &ClientConfig{
+		Address:    address,
+		AuthSecret: authSecret,
+		Log:        LogValue(os.Getenv("FFMPEG_OVER_IP_CLIENT_LOG")),
+	}
+}
+
+// parseLaxBool parses a boolean string leniently.
+// "true", "1", "yes", "y" (case-insensitive) → true; everything else → false.
+func parseLaxBool(s string) bool {
+	switch strings.ToLower(s) {
+	case "true", "1", "yes", "y":
+		return true
+	default:
+		return false
+	}
 }
 
 func loadConfigBytes(explicitPath, configType string) ([]byte, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,6 +98,10 @@ func TestLoadConfigEnvVar(t *testing.T) {
 }
 
 func TestLoadConfigSearchPath(t *testing.T) {
+	t.Setenv("FFMPEG_OVER_IP_SERVER_CONFIG", "")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_ADDRESS", "")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_AUTH_SECRET", "")
+
 	dir := t.TempDir()
 
 	// Write config to the "cwd" search path
@@ -122,8 +126,10 @@ func TestLoadConfigSearchPath(t *testing.T) {
 }
 
 func TestLoadConfigNoFileFound(t *testing.T) {
-	// Clear env var to prevent interference
+	// Clear env vars to prevent interference
 	t.Setenv("FFMPEG_OVER_IP_SERVER_CONFIG", "")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_ADDRESS", "")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_AUTH_SECRET", "")
 
 	// Use a temp dir as cwd where no config exists
 	dir := t.TempDir()
@@ -283,15 +289,17 @@ func TestLoadServerConfigEnvVar(t *testing.T) {
 }
 
 func TestLoadConfigHiddenFile(t *testing.T) {
+	// Clear env vars to prevent interference
+	t.Setenv("FFMPEG_OVER_IP_SERVER_CONFIG", "")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_ADDRESS", "")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_AUTH_SECRET", "")
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".ffmpeg-over-ip.server.jsonc")
 	os.WriteFile(path, []byte(`{
 		"address": "hidden:5050",
 		"authSecret": "hidden-secret"
 	}`), 0o644)
-
-	// Clear env var to prevent interference
-	t.Setenv("FFMPEG_OVER_IP_SERVER_CONFIG", "")
 
 	origDir, _ := os.Getwd()
 	os.Chdir(dir)
@@ -1105,6 +1113,171 @@ func TestServerConfigDebugDefaultFalse(t *testing.T) {
 	}
 	if cfg.Debug {
 		t.Error("Debug = true, want false (should default to false)")
+	}
+}
+
+func TestServerConfigFromEnv(t *testing.T) {
+	t.Setenv("FFMPEG_OVER_IP_SERVER_CONFIG", "")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_ADDRESS", "10.0.0.1:5050")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_AUTH_SECRET", "env-secret")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_LOG", "stderr")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_DEBUG", "yes")
+
+	cfg, err := LoadServerConfig("")
+	if err != nil {
+		t.Fatalf("LoadServerConfig from env failed: %v", err)
+	}
+	if cfg.Address != "10.0.0.1:5050" {
+		t.Errorf("Address = %q, want %q", cfg.Address, "10.0.0.1:5050")
+	}
+	if cfg.AuthSecret != "env-secret" {
+		t.Errorf("AuthSecret = %q, want %q", cfg.AuthSecret, "env-secret")
+	}
+	if cfg.Log != "stderr" {
+		t.Errorf("Log = %q, want %q", cfg.Log, "stderr")
+	}
+	if !cfg.Debug {
+		t.Error("Debug = false, want true")
+	}
+	if cfg.Rewrites != nil {
+		t.Errorf("Rewrites = %v, want nil", cfg.Rewrites)
+	}
+}
+
+func TestClientConfigFromEnv(t *testing.T) {
+	t.Setenv("FFMPEG_OVER_IP_CLIENT_CONFIG", "")
+	t.Setenv("FFMPEG_OVER_IP_CLIENT_ADDRESS", "192.168.1.100:5050")
+	t.Setenv("FFMPEG_OVER_IP_CLIENT_AUTH_SECRET", "client-env-secret")
+	t.Setenv("FFMPEG_OVER_IP_CLIENT_LOG", "/tmp/client.log")
+
+	cfg, err := LoadClientConfig("")
+	if err != nil {
+		t.Fatalf("LoadClientConfig from env failed: %v", err)
+	}
+	if cfg.Address != "192.168.1.100:5050" {
+		t.Errorf("Address = %q, want %q", cfg.Address, "192.168.1.100:5050")
+	}
+	if cfg.AuthSecret != "client-env-secret" {
+		t.Errorf("AuthSecret = %q, want %q", cfg.AuthSecret, "client-env-secret")
+	}
+	if cfg.Log != "/tmp/client.log" {
+		t.Errorf("Log = %q, want %q", cfg.Log, "/tmp/client.log")
+	}
+}
+
+func TestEnvConfigRequiresBothFields(t *testing.T) {
+	// Only ADDRESS set — should fall through to file search (and fail)
+	t.Setenv("FFMPEG_OVER_IP_SERVER_CONFIG", "")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_ADDRESS", "10.0.0.1:5050")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_AUTH_SECRET", "")
+
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	_, err := LoadServerConfig("")
+	if err == nil {
+		t.Fatal("expected error when only ADDRESS is set (should fall through to file search)")
+	}
+}
+
+func TestEnvConfigRequiresBothFieldsClient(t *testing.T) {
+	// Only AUTH_SECRET set — should fall through to file search (and fail)
+	t.Setenv("FFMPEG_OVER_IP_CLIENT_CONFIG", "")
+	t.Setenv("FFMPEG_OVER_IP_CLIENT_ADDRESS", "")
+	t.Setenv("FFMPEG_OVER_IP_CLIENT_AUTH_SECRET", "secret-only")
+
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	_, err := LoadClientConfig("")
+	if err == nil {
+		t.Fatal("expected error when only AUTH_SECRET is set (should fall through to file search)")
+	}
+}
+
+func TestConfigFileEnvTakesPrecedenceOverIndividualEnvVars(t *testing.T) {
+	// _CONFIG env var should take precedence over individual env vars
+	dir := t.TempDir()
+	path := filepath.Join(dir, "priority.jsonc")
+	os.WriteFile(path, []byte(`{
+		"address": "file-wins:5050",
+		"authSecret": "file-secret"
+	}`), 0o644)
+
+	t.Setenv("FFMPEG_OVER_IP_SERVER_CONFIG", path)
+	t.Setenv("FFMPEG_OVER_IP_SERVER_ADDRESS", "env-loses:5050")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_AUTH_SECRET", "env-secret")
+
+	cfg, err := LoadServerConfig("")
+	if err != nil {
+		t.Fatalf("LoadServerConfig failed: %v", err)
+	}
+	if cfg.Address != "file-wins:5050" {
+		t.Errorf("Address = %q, want %q (_CONFIG should take precedence)", cfg.Address, "file-wins:5050")
+	}
+}
+
+func TestExplicitPathTakesPrecedenceOverEnvVars(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "explicit.jsonc")
+	os.WriteFile(path, []byte(`{
+		"address": "explicit-wins:5050",
+		"authSecret": "explicit-secret"
+	}`), 0o644)
+
+	t.Setenv("FFMPEG_OVER_IP_SERVER_CONFIG", "")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_ADDRESS", "env-loses:5050")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_AUTH_SECRET", "env-secret")
+
+	cfg, err := LoadServerConfig(path)
+	if err != nil {
+		t.Fatalf("LoadServerConfig failed: %v", err)
+	}
+	if cfg.Address != "explicit-wins:5050" {
+		t.Errorf("Address = %q, want %q (explicit path should take precedence)", cfg.Address, "explicit-wins:5050")
+	}
+}
+
+func TestServerEnvConfigMinimal(t *testing.T) {
+	// Only required fields, no LOG or DEBUG
+	t.Setenv("FFMPEG_OVER_IP_SERVER_CONFIG", "")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_ADDRESS", "0.0.0.0:9090")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_AUTH_SECRET", "minimal-secret")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_LOG", "")
+	t.Setenv("FFMPEG_OVER_IP_SERVER_DEBUG", "")
+
+	cfg, err := LoadServerConfig("")
+	if err != nil {
+		t.Fatalf("LoadServerConfig from env failed: %v", err)
+	}
+	if cfg.Address != "0.0.0.0:9090" {
+		t.Errorf("Address = %q, want %q", cfg.Address, "0.0.0.0:9090")
+	}
+	if cfg.Log != "" {
+		t.Errorf("Log = %q, want empty", cfg.Log)
+	}
+	if cfg.Debug {
+		t.Error("Debug = true, want false")
+	}
+}
+
+func TestParseLaxBool(t *testing.T) {
+	trueCases := []string{"true", "True", "TRUE", "1", "yes", "Yes", "YES", "y", "Y"}
+	for _, s := range trueCases {
+		if !parseLaxBool(s) {
+			t.Errorf("parseLaxBool(%q) = false, want true", s)
+		}
+	}
+
+	falseCases := []string{"", "false", "0", "no", "n", "nope", "anything"}
+	for _, s := range falseCases {
+		if parseLaxBool(s) {
+			t.Errorf("parseLaxBool(%q) = true, want false", s)
+		}
 	}
 }
 


### PR DESCRIPTION
Allow client and server to be configured entirely through env vars (FFMPEG_OVER_IP_{CLIENT,SERVER}_{ADDRESS,AUTH_SECRET,LOG,DEBUG}) when no _CONFIG env var or --config flag is present. This enables Docker and scripted deployments without mounting config files.

Resolves #13