### PR TITLE
Allow 32-bit PowerShell on 64-bit Windows in install scripts

### DIFF
--- a/scripts/install-client.ps1
+++ b/scripts/install-client.ps1
@@ -15,9 +15,9 @@ $Config = "ffmpeg-over-ip.$Role.jsonc"
 
 # --- Platform detection -----------------------------------------------------
 
-$archEnum = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-if ($archEnum -ne 'X64') {
-    throw "Unsupported architecture: $archEnum. Only Windows x64 builds are published."
+# Gate on OS bitness, not process bitness — we never execute the downloaded binary here.
+if (-not [Environment]::Is64BitOperatingSystem) {
+    throw "Unsupported operating system: 32-bit Windows. Only 64-bit Windows is supported."
 }
 $Platform = 'windows-amd64'
 

--- a/scripts/install-server.ps1
+++ b/scripts/install-server.ps1
@@ -15,9 +15,9 @@ $Config = "ffmpeg-over-ip.$Role.jsonc"
 
 # --- Platform detection -----------------------------------------------------
 
-$archEnum = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-if ($archEnum -ne 'X64') {
-    throw "Unsupported architecture: $archEnum. Only Windows x64 builds are published."
+# Gate on OS bitness, not process bitness — we never execute the downloaded binary here.
+if (-not [Environment]::Is64BitOperatingSystem) {
+    throw "Unsupported operating system: 32-bit Windows. Only 64-bit Windows is supported."
 }
 $Platform = 'windows-amd64'
 


### PR DESCRIPTION
## Summary

- Replace the `[RuntimeInformation]::OSArchitecture` check in both PowerShell install scripts with `[Environment]::Is64BitOperatingSystem`. The old check returned `X86` under WoW64 in PS 5.1 (a .NET Framework quirk), so users on the default Windows PowerShell shortcut hit `Unsupported architecture: X86` even on fully supported 64-bit Windows — see #9.
- The install scripts never execute the downloaded binary, so process bitness is irrelevant. Gating on OS bitness means a 32-bit PS session on 64-bit Windows installs a working 64-bit binary just fine, while genuine 32-bit Windows is still rejected with a clear error.

## Test plan

- [ ] Run `irm https://ffmpeg-over-ip.com/install-client.ps1 | iex` in a 32-bit PowerShell on 64-bit Windows — should complete without the architecture error.
- [ ] Run the same in 64-bit PowerShell on 64-bit Windows — should complete normally (regression check).
- [ ] Confirm 32-bit Windows still gets `Unsupported operating system: 32-bit Windows. Only 64-bit Windows is supported.`
- [ ] Repeat the above three for `install-server.ps1`.