### PR TITLE
Make rewrites argv-aware (whole-element match, multi-token support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,8 +22,8 @@ If both `ADDRESS` and `AUTH_SECRET` env vars are set (and no `_CONFIG` env var i
 | `FFMPEG_OVER_IP_CLIENT_ADDRESS` | Yes | Server address (`host:port` or `unix:/path`) |
 | `FFMPEG_OVER_IP_CLIENT_AUTH_SECRET` | Yes | HMAC auth secret (must match server) |
 | `FFMPEG_OVER_IP_CLIENT_LOG` | No | Log destination: `stdout`, `stderr`, or file path |
-| `FFMPEG_OVER_IP_CLIENT_FALLBACK_TO_LOCAL` | No | Run local ffmpeg if the server is unreachable (`true`, `1`, `yes`, `y`) |
-| `FFMPEG_OVER_IP_CLIENT_DEBUG` | No | Log original/rewritten args when fallback runs (`true`, `1`, `yes`, `y`) |
+| `FFMPEG_OVER_IP_CLIENT_FALLBACK_TO_LOCAL` | No | Run local ffmpeg if the server is unreachable (`true`, `1`, `yes`, `y` — case-insensitive) |
+| `FFMPEG_OVER_IP_CLIENT_DEBUG` | No | Log original/rewritten args when fallback runs (`true`, `1`, `yes`, `y` — case-insensitive) |
 
 ### Server
 
@@ -32,7 +32,7 @@ If both `ADDRESS` and `AUTH_SECRET` env vars are set (and no `_CONFIG` env var i
 | `FFMPEG_OVER_IP_SERVER_ADDRESS` | Yes | Listen address (`host:port` or `unix:/path`) |
 | `FFMPEG_OVER_IP_SERVER_AUTH_SECRET` | Yes | HMAC auth secret (must match client) |
 | `FFMPEG_OVER_IP_SERVER_LOG` | No | Log destination: `stdout`, `stderr`, or file path |
-| `FFMPEG_OVER_IP_SERVER_DEBUG` | No | Log original/rewritten args (`true`, `1`, `yes`, `y`) |
+| `FFMPEG_OVER_IP_SERVER_DEBUG` | No | Log original/rewritten args (`true`, `1`, `yes`, `y` — case-insensitive) |
 
 Rewrites (server `rewrites` and client `fallbackRewrites`) are not supported via environment variables — use a config file if you need them.
 
@@ -61,7 +61,7 @@ If no explicit path or env var config is used, the first file found wins:
 
 The server also accepts `--config <path>`.
 
-On Windows, `~` is your user directory (e.g., `C:\Users\<you>`). Paths 7 and 8 don't apply — use the binary directory, current directory, or an environment variable instead.
+On Windows, `~` is your user directory (e.g., `C:\Users\<you>`). The `/etc/...` and `/usr/local/etc/...` paths are still searched but won't exist on a stock install — use the binary directory, current directory, or an environment variable instead.
 
 To see which paths are searched on your system, run:
 
@@ -74,7 +74,9 @@ ffmpeg-over-ip-client --debug-print-search-paths
 
 ```jsonc
 {
+  // Required: listen address (host:port or unix:/path/to/socket)
   "address": "0.0.0.0:5050",
+  // Required: HMAC auth secret — must match client
   "authSecret": "your-secret-here",
   // Optional: see "Log" section below (default: no logging)
   "log": "stdout",
@@ -93,7 +95,9 @@ The server looks for `ffmpeg` and `ffprobe` in the same directory as its own bin
 
 ```jsonc
 {
+  // Required: server address (host:port or unix:/path/to/socket)
   "address": "192.168.1.100:5050",
+  // Required: HMAC auth secret — must match server
   "authSecret": "your-secret-here",
   // Optional: see "Log" section below
   "log": "/tmp/ffmpeg-over-ip.log",
@@ -156,7 +160,7 @@ Security notes:
 
 ## Rewrites
 
-Rewrites let the server substitute strings in ffmpeg arguments before running the command. This is useful when the client requests a codec the server doesn't have — for example, the client asks for `h264_nvenc` but the server has Intel QSV instead of NVIDIA.
+Rewrites let the server substitute argv elements in ffmpeg arguments before running the command. This is useful when the client requests a codec the server doesn't have — for example, the client asks for `h264_nvenc` but the server has Intel QSV instead of NVIDIA.
 
 ```jsonc
 {
@@ -167,7 +171,29 @@ Rewrites let the server substitute strings in ffmpeg arguments before running th
 }
 ```
 
-Each pair `["from", "to"]` does a plain string replacement across all ffmpeg arguments. In the example above, any argument containing `h264_nvenc` is rewritten to `h264_qsv`.
+Each pair `["find", "replace"]` matches whole argv elements — not substrings within them. The example above rewrites any argv element exactly equal to `h264_nvenc` to `h264_qsv`. An element like `h264_nvenc_extra` would not match.
+
+`find` and `replace` are each split on whitespace, so a single rewrite can match a consecutive run of argv elements and substitute a run of different length:
+
+```jsonc
+{
+  "rewrites": [
+    // Swap a two-element run (-hwaccel qsv) for a different two-element run.
+    ["-hwaccel qsv", "-hwaccel cuda"],
+
+    // Expand a two-element run into a four-element run.
+    ["-hwaccel qsv", "-hwaccel cuda -hwaccel_output_format cuda"],
+
+    // Remove a one-element argv entry entirely (empty replacement).
+    ["-nostdin", ""],
+
+    // Remove a two-element run.
+    ["-preset veryfast", ""],
+  ],
+}
+```
+
+Rewrites are applied in declared order, so a later rewrite can match tokens produced by an earlier one. The same rewrite is applied to every matching run in argv, not just the first.
 
 Enable `"debug": true` to log original and rewritten arguments for each command.
 

--- a/internal/rewrite/rewrite.go
+++ b/internal/rewrite/rewrite.go
@@ -1,22 +1,64 @@
-// Package rewrite applies ordered string-replacement pairs to ffmpeg argv.
+// Package rewrite applies ordered argv-element rewrite pairs to ffmpeg argv.
 // Used by the server (server-side rewrites) and by the client (fallback
 // rewrites when execing the local ffmpeg).
 package rewrite
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
-// Apply returns a copy of args with each rewrite pair applied in order via
-// strings.ReplaceAll. If rewrites is empty, the input slice is returned as-is.
+// Apply returns a copy of args with each rewrite pair applied in order.
+//
+// Each rewrite is [find, replace]. Both are split on whitespace via
+// strings.Fields, giving a sequence of tokens. A rewrite matches when the
+// find tokens equal a consecutive run of whole argv elements; the matched
+// run is replaced by the replace tokens (which may be longer, shorter, or
+// empty — an empty or whitespace-only replace removes the matched run).
+// Substring matching within an argv element is not supported — patterns
+// must align on argv boundaries.
+//
+// Examples:
+//
+//	{"h264_nvenc", "h264_qsv"}            // 1→1: swap one element
+//	{"-hwaccel qsv", "-hwaccel cuda"}     // 2→2: swap a two-element run
+//	{"-hwaccel qsv",                      // 2→4: expand a two-element run
+//	 "-hwaccel cuda -hwaccel_output_format cuda"}
+//	{"-nostdin", ""}                       // 1→0: remove an element
+//
+// Rewrites are applied sequentially, so a later rewrite can match tokens
+// produced by an earlier one.
+//
+// If rewrites is empty, the input slice is returned as-is.
 func Apply(args []string, rewrites [][2]string) []string {
 	if len(rewrites) == 0 {
 		return args
 	}
-	result := make([]string, len(args))
-	for i, arg := range args {
-		result[i] = arg
-		for _, rw := range rewrites {
-			result[i] = strings.ReplaceAll(result[i], rw[0], rw[1])
+	out := append([]string(nil), args...)
+	for _, rw := range rewrites {
+		find := strings.Fields(rw[0])
+		if len(find) == 0 {
+			continue
 		}
+		repl := strings.Fields(rw[1])
+		out = applyOne(out, find, repl)
 	}
-	return result
+	return out
+}
+
+// applyOne scans args once, replacing every non-overlapping run of elements
+// equal to find with repl. Scanning resumes past the spliced-in repl, so a
+// rewrite that produces tokens matching its own find won't loop.
+func applyOne(args, find, repl []string) []string {
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); {
+		if i+len(find) <= len(args) && slices.Equal(args[i:i+len(find)], find) {
+			out = append(out, repl...)
+			i += len(find)
+			continue
+		}
+		out = append(out, args[i])
+		i++
+	}
+	return out
 }

--- a/internal/rewrite/rewrite_test.go
+++ b/internal/rewrite/rewrite_test.go
@@ -10,6 +10,7 @@ func TestApply(t *testing.T) {
 		want     []string
 		sameRef  bool // if true, expect returned slice is the same reference as input
 	}{
+		// --- Identity / no-op ---
 		{
 			name:     "empty rewrites returns same slice",
 			args:     []string{"-c:v", "h264_nvenc", "-i", "input.mp4"},
@@ -25,19 +26,16 @@ func TestApply(t *testing.T) {
 			sameRef:  true,
 		},
 		{
-			name:     "single rewrite replaces codec",
-			args:     []string{"-c:v", "h264_nvenc", "-i", "input.mp4"},
-			rewrites: [][2]string{{"h264_nvenc", "h264_qsv"}},
-			want:     []string{"-c:v", "h264_qsv", "-i", "input.mp4"},
+			name:     "empty args with non-empty rewrites returns empty result",
+			args:     []string{},
+			rewrites: [][2]string{{"a", "b"}},
+			want:     []string{},
 		},
 		{
-			name: "multiple rewrites applied in order",
-			args: []string{"-c:v", "h264_nvenc", "-preset", "fast"},
-			rewrites: [][2]string{
-				{"h264_nvenc", "h264_qsv"},
-				{"fast", "medium"},
-			},
-			want: []string{"-c:v", "h264_qsv", "-preset", "medium"},
+			name:     "nil args with non-empty rewrites returns empty result",
+			args:     nil,
+			rewrites: [][2]string{{"a", "b"}},
+			want:     []string{},
 		},
 		{
 			name:     "rewrite that does not match leaves args unchanged",
@@ -46,25 +44,54 @@ func TestApply(t *testing.T) {
 			want:     []string{"-c:v", "libx264", "-i", "input.mp4"},
 		},
 		{
-			name:     "rewrite applied to all args not just first match",
+			name:     "empty find token is skipped",
+			args:     []string{"-c:v", "libx264"},
+			rewrites: [][2]string{{"", "anything"}, {"   ", "anything"}},
+			want:     []string{"-c:v", "libx264"},
+		},
+
+		// --- Single-token rewrites (whole-arg match) ---
+		{
+			name:     "single rewrite replaces matching element",
+			args:     []string{"-c:v", "h264_nvenc", "-i", "input.mp4"},
+			rewrites: [][2]string{{"h264_nvenc", "h264_qsv"}},
+			want:     []string{"-c:v", "h264_qsv", "-i", "input.mp4"},
+		},
+		{
+			name:     "single rewrite applied to every matching element",
 			args:     []string{"h264_nvenc", "foo", "h264_nvenc"},
 			rewrites: [][2]string{{"h264_nvenc", "h264_qsv"}},
 			want:     []string{"h264_qsv", "foo", "h264_qsv"},
 		},
 		{
-			name:     "rewrite with empty replacement deletes pattern",
+			name:     "single-token find requires whole-arg match (no substring rewrite)",
+			args:     []string{"h264_nvenc_extra", "h264_nvenc"},
+			rewrites: [][2]string{{"h264_nvenc", "h264_qsv"}},
+			want:     []string{"h264_nvenc_extra", "h264_qsv"},
+		},
+		{
+			name:     "single-token rewrite with empty replacement removes element",
 			args:     []string{"-nostdin", "-c:v", "libx264"},
 			rewrites: [][2]string{{"-nostdin", ""}},
-			want:     []string{"", "-c:v", "libx264"},
+			want:     []string{"-c:v", "libx264"},
 		},
 		{
-			name:     "multiple occurrences of pattern in one arg",
-			args:     []string{"aa-bb-aa", "cc"},
-			rewrites: [][2]string{{"aa", "xx"}},
-			want:     []string{"xx-bb-xx", "cc"},
+			name:     "whitespace-only replacement is equivalent to empty (removes element)",
+			args:     []string{"-nostdin", "-c:v", "libx264"},
+			rewrites: [][2]string{{"-nostdin", "   "}},
+			want:     []string{"-c:v", "libx264"},
 		},
 		{
-			name: "chained rewrites where first produces text matched by second",
+			name: "multiple single-token rewrites applied in order",
+			args: []string{"-c:v", "h264_nvenc", "-preset", "fast"},
+			rewrites: [][2]string{
+				{"h264_nvenc", "h264_qsv"},
+				{"fast", "medium"},
+			},
+			want: []string{"-c:v", "h264_qsv", "-preset", "medium"},
+		},
+		{
+			name: "chained rewrites where first produces token matched by second",
 			args: []string{"alpha"},
 			rewrites: [][2]string{
 				{"alpha", "beta"},
@@ -73,16 +100,92 @@ func TestApply(t *testing.T) {
 			want: []string{"gamma"},
 		},
 		{
-			name:     "empty args with non-empty rewrites returns empty result",
-			args:     []string{},
-			rewrites: [][2]string{{"a", "b"}},
-			want:     []string{},
+			name: "chained rewrites across token-count changes (2 to 2 then 2 to 1)",
+			args: []string{"a", "b"},
+			rewrites: [][2]string{
+				{"a b", "c d"},
+				{"c d", "e"},
+			},
+			want: []string{"e"},
+		},
+
+		// --- Multi-token rewrites (consecutive argv run match) ---
+		{
+			name:     "multi-token 2 to 2 swap",
+			args:     []string{"-hwaccel", "qsv", "-i", "in.mp4"},
+			rewrites: [][2]string{{"-hwaccel qsv", "-hwaccel cuda"}},
+			want:     []string{"-hwaccel", "cuda", "-i", "in.mp4"},
 		},
 		{
-			name:     "rewrite matching part of arg",
-			args:     []string{"-c:v h264_nvenc", "-preset fast"},
-			rewrites: [][2]string{{"h264_nvenc", "h264_qsv"}},
-			want:     []string{"-c:v h264_qsv", "-preset fast"},
+			name:     "multi-token 2 to 4 expansion",
+			args:     []string{"-hwaccel", "qsv", "-i", "in.mp4"},
+			rewrites: [][2]string{{"-hwaccel qsv", "-hwaccel cuda -hwaccel_output_format cuda"}},
+			want:     []string{"-hwaccel", "cuda", "-hwaccel_output_format", "cuda", "-i", "in.mp4"},
+		},
+		{
+			name:     "multi-token 4 to 2 contraction",
+			args:     []string{"-hwaccel", "cuda", "-hwaccel_output_format", "cuda", "-i", "in.mp4"},
+			rewrites: [][2]string{{"-hwaccel cuda -hwaccel_output_format cuda", "-hwaccel qsv"}},
+			want:     []string{"-hwaccel", "qsv", "-i", "in.mp4"},
+		},
+		{
+			name:     "multi-token with empty replacement deletes run",
+			args:     []string{"-preset", "veryfast", "-i", "in.mp4"},
+			rewrites: [][2]string{{"-preset veryfast", ""}},
+			want:     []string{"-i", "in.mp4"},
+		},
+		{
+			name:     "multi-token applied to every occurrence",
+			args:     []string{"-c:v", "h264_qsv", "-c:a", "aac", "-c:v", "h264_qsv"},
+			rewrites: [][2]string{{"-c:v h264_qsv", "-c:v h264_nvenc"}},
+			want:     []string{"-c:v", "h264_nvenc", "-c:a", "aac", "-c:v", "h264_nvenc"},
+		},
+		{
+			name:     "multi-token does not match when only the first token aligns",
+			args:     []string{"-hwaccel", "vaapi", "-i", "in.mp4"},
+			rewrites: [][2]string{{"-hwaccel qsv", "-hwaccel cuda"}},
+			want:     []string{"-hwaccel", "vaapi", "-i", "in.mp4"},
+		},
+		{
+			name:     "multi-token does not match when args slice is shorter than find",
+			args:     []string{"-hwaccel"},
+			rewrites: [][2]string{{"-hwaccel qsv", "-hwaccel cuda"}},
+			want:     []string{"-hwaccel"},
+		},
+		{
+			name:     "multi-token scan resumes past replacement, no self-loop",
+			args:     []string{"a", "b"},
+			rewrites: [][2]string{{"a b", "a b c"}},
+			want:     []string{"a", "b", "c"},
+		},
+		{
+			name:     "multi-token matches are non-overlapping",
+			args:     []string{"a", "a", "a"},
+			rewrites: [][2]string{{"a a", "x"}},
+			want:     []string{"x", "a"},
+		},
+		{
+			name:     "multi-token matches back-to-back occurrences",
+			args:     []string{"a", "b", "a", "b"},
+			rewrites: [][2]string{{"a b", "x"}},
+			want:     []string{"x", "x"},
+		},
+		{
+			name:     "whitespace in find is collapsed via strings.Fields",
+			args:     []string{"-hwaccel", "qsv"},
+			rewrites: [][2]string{{"  -hwaccel    qsv  ", "-hwaccel cuda"}},
+			want:     []string{"-hwaccel", "cuda"},
+		},
+
+		// --- Mixed single- and multi-token rewrites ---
+		{
+			name: "mixed single-token and multi-token rewrites applied in order",
+			args: []string{"-c:v", "h264_qsv", "-preset", "veryfast"},
+			rewrites: [][2]string{
+				{"-c:v h264_qsv", "-c:v h264_nvenc"},
+				{"veryfast", "p1"},
+			},
+			want: []string{"-c:v", "h264_nvenc", "-preset", "p1"},
 		},
 	}
 
@@ -91,7 +194,7 @@ func TestApply(t *testing.T) {
 			got := Apply(tt.args, tt.rewrites)
 
 			if len(got) != len(tt.want) {
-				t.Fatalf("length mismatch: got %d, want %d", len(got), len(tt.want))
+				t.Fatalf("length mismatch: got %d (%v), want %d (%v)", len(got), got, len(tt.want), tt.want)
 			}
 
 			for i := range tt.want {

--- a/template.ffmpeg-over-ip.client.jsonc
+++ b/template.ffmpeg-over-ip.client.jsonc
@@ -17,6 +17,31 @@
   // "address": "server.example.com:5050"           // Connect to a remote server
   // "address": "unix:/tmp/ffmpeg-over-ip.sock"     // Connect using Unix socket
 
-  "authSecret": "YOUR-CLIENT-PASSWORD-HERE" // type: string
+  "authSecret": "YOUR-CLIENT-PASSWORD-HERE", // type: string
   // ^ This MUST match what you have in the server
+
+  // Optional: when true, fall back to running the host's local ffmpeg
+  // (looked up on $PATH) if the server is unreachable. Useful for media
+  // servers like Jellyfin where any transcoder is better than none.
+  // Defaults to false.
+  "fallbackToLocal": false, // type: boolean
+
+  // Optional: rewrites applied to argv before exec'ing the local ffmpeg
+  // when "fallbackToLocal" is enabled and the server is unreachable.
+  // Same format and semantics as the server's "rewrites": ["find", "replace"]
+  // matches whole argv elements, and both find and replace are split on
+  // whitespace so a single rewrite can match or expand a run of elements.
+  "fallbackRewrites": [
+    // Swap one argv element for another (single-token):
+    // ["h264_nvenc", "h264_qsv"],
+
+    // Swap a two-element run (multi-token):
+    // ["-hwaccel cuda", "-hwaccel qsv"],
+
+    // Expand a two-element run into a four-element run:
+    // ["-hwaccel qsv", "-hwaccel cuda -hwaccel_output_format cuda"],
+
+    // Remove an argv element (empty replacement):
+    // ["-nostdin", ""],
+  ]
 }

--- a/template.ffmpeg-over-ip.server.jsonc
+++ b/template.ffmpeg-over-ip.server.jsonc
@@ -24,8 +24,21 @@
   // ^ When set to true, original and rewritten args will be logged for each command
   // This is useful for troubleshooting ffmpeg commands and rewrites
 
-  // Optional: rewrite codec names in ffmpeg arguments
+  // Optional: rewrite argv elements in ffmpeg arguments before exec.
+  // ["find", "replace"] matches whole argv elements (not substrings).
+  // Both find and replace are split on whitespace, so a single rewrite
+  // can match or expand a run of argv elements.
   "rewrites": [
-    ["libfdk_aac", "aac"]
+    // Swap one argv element for another (single-token):
+    // ["libfdk_aac", "aac"],
+
+    // Swap a two-element run (multi-token):
+    // ["-hwaccel qsv", "-hwaccel cuda"],
+
+    // Expand a two-element run into a four-element run:
+    // ["-hwaccel qsv", "-hwaccel cuda -hwaccel_output_format cuda"],
+
+    // Remove an argv element (empty replacement):
+    // ["-nostdin", ""],
   ]
 }


### PR DESCRIPTION
Previously, the rewrite engine ran strings.ReplaceAll on each argv element, so a rewrite like ["nvenc", "qsv"] would substring-rewrite inside any arg containing "nvenc" — surprising and easy to misuse. It also couldn't express patterns spanning multiple argv elements, which is exactly what GPU-vendor translation needs (issue #16):

    ["-hwaccel qsv", "-hwaccel cuda -hwaccel_output_format cuda"]

New semantics in internal/rewrite/rewrite.go:

- find and replace are each split on whitespace via strings.Fields, giving a sequence of tokens.
- A rewrite matches when find's tokens equal a consecutive run of whole argv elements; the matched run is replaced by replace's tokens.
- Empty / whitespace-only replace removes the matched run entirely (previously left an empty string in the slot, which ffmpeg would have errored on anyway).
- Single-token rewrites are just the N=1 case — no substring matching.
- Rewrites applied in declared order; same rewrite fires for every matching run, not just the first.

Breaking change: any existing config like ["nvenc", "qsv"] that relied on substring rewriting inside h264_nvenc-style args silently stops working and must be rewritten to ["h264_nvenc", "h264_qsv"].

Other changes:

- docs/configuration.md:
  - Rewrites section updated for the new semantics, with examples covering 2->2 swap, 2->4 expansion, and 1->0 / 2->0 deletion.
  - "address" and "authSecret" marked Required in the Server/Client config code blocks (the loader errors if either is empty).
  - Env-var bool descriptions note case-insensitivity (parseLaxBool lowercases the input).
  - Windows note about search paths quotes /etc/... and /usr/local/etc/... by path rather than by list index.

- template.ffmpeg-over-ip.server.jsonc: rewrites array ships empty; commented-out examples illustrate single-token, multi-token, and deletion forms.

- template.ffmpeg-over-ip.client.jsonc: add fallbackToLocal and fallbackRewrites (both were already real config fields but only documented in docs/configuration.md, not in the template).

- internal/rewrite/rewrite_test.go: reorganized into single-token / multi-token / mixed sections. Dropped two cases that locked in substring matching ("rewrite matching part of arg", "multiple occurrences of pattern in one arg"). Updated the empty-replacement case to assert removal. Added coverage for 2->2 swap, 2->4 expansion, 4->2 contraction, deletion, whitespace collapsing, non-overlapping matches, back-to-back matches, short-args no-match, nil args input, and chained rewrites across token-count changes.