### PR TITLE
WIP: Upgrade to ffmpeg-8.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,97 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository.
+
+## Project Shape
+
+`ffmpeg-over-ip` lets a client machine run a local-looking `ffmpeg` or `ffprobe` command on a remote server that has GPU access. The server runs a patched FFmpeg binary; the patch redirects FFmpeg file operations through a C `fio` layer, and the Go client performs those file operations against the client's local filesystem.
+
+High-level flow:
+
+1. `cmd/client` loads client config, signs the command with HMAC, connects to the server, forwards stdin/stdout/stderr, and services tunneled file I/O requests.
+2. `cmd/server` authenticates the command, applies configured argv rewrites, launches same-directory `ffmpeg` or `ffprobe`, and runs a session.
+3. `internal/process` starts patched FFmpeg with `FFOIP_PORT` pointing at a local loopback listener.
+4. `fio/` connects to that loopback port when `FFOIP_PORT` is set and sends file-operation messages.
+5. `internal/session` bridges FFmpeg loopback I/O, stdio, cancellation, keepalives, and exit codes over the client/server connection.
+6. `internal/filehandler` executes the file operations on the client filesystem.
+
+## Key Directories
+
+- `cmd/client/` - drop-in client binary for `ffmpeg` and `ffprobe`; includes local fallback behavior.
+- `cmd/server/` - daemon that launches patched `ffmpeg`/`ffprobe`.
+- `internal/protocol/` - wire protocol types, message envelopes, and encoders/decoders.
+- `internal/session/` - connection/session multiplexing between TCP, process pipes, and fio loopback.
+- `internal/process/` - child process lifecycle and `FFOIP_PORT` loopback setup.
+- `internal/filehandler/` - local filesystem implementation of remote file requests.
+- `internal/config/` - JSONC/env config loading, logging setup, address parsing.
+- `internal/auth/` - HMAC-SHA256 command signing and verification.
+- `internal/rewrite/` - ordered argv rewrite rules.
+- `fio/` - C tunneling layer patched into FFmpeg. GPL v3.
+- `patches/` - patches applied to Jellyfin FFmpeg. GPL v3.
+- `third_party/jellyfin-ffmpeg/` - upstream Jellyfin FFmpeg submodule; avoid editing directly unless the task explicitly requires it.
+- `scripts/` - build and install scripts.
+- `tests/integration/` - end-to-end shell tests requiring patched FFmpeg.
+- `tests/static-analysis/` - scan for raw file syscalls in patched FFmpeg.
+
+## Build And Test Commands
+
+Common checks:
+
+```sh
+go build ./...
+go test ./internal/... ./cmd/... -race -count=1 -timeout 120s
+```
+
+C fio tests:
+
+```sh
+cd fio
+make test
+```
+
+Build minimal patched FFmpeg for integration testing:
+
+```sh
+bash scripts/build-ffmpeg.sh --minimal
+```
+
+Run integration tests after patched FFmpeg exists at `build/ffmpeg/bin/ffmpeg`:
+
+```sh
+bash tests/integration/test-client-server.sh
+for t in tests/integration/test-*.sh; do bash "$t"; done
+```
+
+Static syscall audit after patching/building FFmpeg:
+
+```sh
+python3 tests/static-analysis/scan-raw-syscalls.py
+```
+
+## Development Notes
+
+- Preserve the protocol contract between Go and C. Message type values, field order, endian encoding, errno constants, and request/response payload layouts must stay in sync between `internal/protocol/wire.go` and `fio/fio.c`.
+- If protocol layout changes, update Go protocol tests, C fio tests, integration tests, and any wire/vector helpers under `tests/wire`.
+- The client must remain an invisible `ffmpeg`/`ffprobe` proxy. Avoid writing diagnostics to stdout/stderr paths that belong to the proxied process unless existing behavior already does so intentionally. Prefer configured logging.
+- `ffprobe` mode is detected from the client executable name containing `ffprobe`.
+- Server `ffmpeg` and `ffprobe` are resolved from the same directory as `ffmpeg-over-ip-server`.
+- Fallback-to-local only happens on initial dial failure. Do not silently restart partially established sessions locally.
+- Keep file I/O behavior cross-platform. The wire protocol uses canonical flags, whence values, and Linux-style errno constants; translate at boundaries.
+- Be careful with raw file syscalls in FFmpeg patches. File operations that should follow client-local paths need `fio_*`; allowed raw syscall uses should be clearly justified and marked consistently with the static-analysis expectations.
+- Avoid unnecessary churn in `third_party/jellyfin-ffmpeg/`. Build scripts copy or patch it as needed.
+- Respect the split license: `fio/` and `patches/` are GPL v3; most Go code and docs are MIT.
+
+## Config And Runtime
+
+- Config files are JSONC.
+- Config resolution supports explicit server `--config`, config env vars, individual address/auth env vars, and search paths documented in `docs/configuration.md`.
+- Address strings are either TCP `host:port` or Unix sockets prefixed with `unix:`.
+- Rewrites match whole argv elements, with multi-token find/replace strings split on whitespace.
+- Env-var config does not support rewrite arrays.
+
+## When Changing Behavior
+
+- Start from the focused unit tests for the package being changed.
+- Run broader tests when touching shared contracts: protocol, session, process lifecycle, config loading, filehandler, `fio/`, or FFmpeg patches.
+- For anything involving the patched FFmpeg path, build minimal FFmpeg and run at least one integration test that exercises both reading and writing through fio.
+- Keep changes scoped. This repository has many generated/vendor/upstream files; do not reformat or regenerate unrelated content.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/patches/001-fio-makefile.patch
+++ b/patches/001-fio-makefile.patch
@@ -1,13 +1,13 @@
 diff --git a/libavformat/Makefile b/libavformat/Makefile
-index 7ca68a7..86d27ac 100644
+index 4786a93..e32e644 100644
 --- a/libavformat/Makefile
 +++ b/libavformat/Makefile
-@@ -672,7 +672,7 @@ OBJS-$(CONFIG_CRYPTO_PROTOCOL)           += crypto.o
+@@ -686,7 +686,7 @@ OBJS-$(CONFIG_CRYPTO_PROTOCOL)           += crypto.o
  OBJS-$(CONFIG_DATA_PROTOCOL)             += data_uri.o
  OBJS-$(CONFIG_FFRTMPCRYPT_PROTOCOL)      += rtmpcrypt.o rtmpdigest.o rtmpdh.o
  OBJS-$(CONFIG_FFRTMPHTTP_PROTOCOL)       += rtmphttp.o
 -OBJS-$(CONFIG_FILE_PROTOCOL)             += file.o
 +OBJS-$(CONFIG_FILE_PROTOCOL)             += file.o fio.o
  OBJS-$(CONFIG_FD_PROTOCOL)               += file.o
- OBJS-$(CONFIG_FTP_PROTOCOL)              += ftp.o urldecode.o
+ OBJS-$(CONFIG_FTP_PROTOCOL)              += ftp.o
  OBJS-$(CONFIG_GOPHER_PROTOCOL)           += gopher.o

--- a/patches/002-file-protocol.patch
+++ b/patches/002-file-protocol.patch
@@ -1,5 +1,5 @@
 diff --git a/libavformat/file.c b/libavformat/file.c
-index 6a66040..9e6b5c5 100644
+index 3ceddc8..d9213b6 100644
 --- a/libavformat/file.c
 +++ b/libavformat/file.c
 @@ -41,6 +41,7 @@
@@ -10,7 +10,7 @@ index 6a66040..9e6b5c5 100644
  
  /* Some systems may not have S_ISFIFO */
  #ifndef S_ISFIFO
-@@ -141,7 +142,7 @@ static int file_read(URLContext *h, unsigned char *buf, int size)
+@@ -143,7 +144,7 @@ static int file_read(URLContext *h, unsigned char *buf, int size)
      FileContext *c = h->priv_data;
      int ret;
      size = FFMIN(size, c->blocksize);
@@ -19,7 +19,7 @@ index 6a66040..9e6b5c5 100644
      if (ret == 0 && c->follow)
          return AVERROR(EAGAIN);
      if (ret == 0)
-@@ -154,7 +155,7 @@ static int file_write(URLContext *h, const unsigned char *buf, int size)
+@@ -156,7 +157,7 @@ static int file_write(URLContext *h, const unsigned char *buf, int size)
      FileContext *c = h->priv_data;
      int ret;
      size = FFMIN(size, c->blocksize);
@@ -28,7 +28,7 @@ index 6a66040..9e6b5c5 100644
      return (ret == -1) ? AVERROR(errno) : ret;
  }
  
-@@ -172,17 +173,17 @@ static int file_check(URLContext *h, int mask)
+@@ -174,17 +175,17 @@ static int file_check(URLContext *h, int mask)
  
      {
  #if HAVE_ACCESS && defined(R_OK)
@@ -50,7 +50,7 @@ index 6a66040..9e6b5c5 100644
      if (ret < 0)
          return AVERROR(errno);
  
-@@ -221,7 +222,7 @@ static int fd_dup(URLContext *h, int oldfd)
+@@ -223,7 +224,7 @@ static int fd_dup(URLContext *h, int oldfd)
  static int file_close(URLContext *h)
  {
      FileContext *c = h->priv_data;
@@ -59,7 +59,7 @@ index 6a66040..9e6b5c5 100644
      return (ret == -1) ? AVERROR(errno) : 0;
  }
  
-@@ -233,11 +234,11 @@ static int64_t file_seek(URLContext *h, int64_t pos, int whence)
+@@ -235,11 +236,11 @@ static int64_t file_seek(URLContext *h, int64_t pos, int whence)
  
      if (whence == AVSEEK_SIZE) {
          struct stat st;
@@ -73,7 +73,7 @@ index 6a66040..9e6b5c5 100644
  
      return ret < 0 ? AVERROR(errno) : ret;
  }
-@@ -246,25 +247,13 @@ static int64_t file_seek(URLContext *h, int64_t pos, int whence)
+@@ -248,25 +249,13 @@ static int64_t file_seek(URLContext *h, int64_t pos, int whence)
  
  static int file_delete(URLContext *h)
  {
@@ -101,7 +101,7 @@ index 6a66040..9e6b5c5 100644
  }
  
  static int file_move(URLContext *h_src, URLContext *h_dst)
-@@ -274,7 +263,7 @@ static int file_move(URLContext *h_src, URLContext *h_dst)
+@@ -276,7 +265,7 @@ static int file_move(URLContext *h_src, URLContext *h_dst)
      av_strstart(filename_src, "file:", &filename_src);
      av_strstart(filename_dst, "file:", &filename_dst);
  
@@ -110,7 +110,7 @@ index 6a66040..9e6b5c5 100644
          return AVERROR(errno);
  
      return 0;
-@@ -303,12 +292,12 @@ static int file_open(URLContext *h, const char *filename, int flags)
+@@ -305,12 +294,12 @@ static int file_open(URLContext *h, const char *filename, int flags)
  #ifdef O_BINARY
      access |= O_BINARY;
  #endif
@@ -123,9 +123,9 @@ index 6a66040..9e6b5c5 100644
 -    h->is_streamed = !fstat(fd, &st) && S_ISFIFO(st.st_mode);
 +    h->is_streamed = !fio_fstat(fd, &st) && S_ISFIFO(st.st_mode);
  
-     /* Buffer writes more than the default 32k to improve throughput especially
-      * with networked file systems */
-@@ -493,7 +482,7 @@ static int fd_open(URLContext *h, const char *filename, int flags)
+     if (c->pkt_size) {
+         h->max_packet_size = c->pkt_size;
+@@ -503,7 +492,7 @@ static int fd_open(URLContext *h, const char *filename, int flags)
              c->fd = 0;
          }
      }
@@ -134,7 +134,7 @@ index 6a66040..9e6b5c5 100644
          return AVERROR(errno);
      h->is_streamed = !(S_ISREG(st.st_mode) || S_ISBLK(st.st_mode));
      c->fd = fd_dup(h, c->fd);
-@@ -627,8 +616,8 @@ static int android_content_open(URLContext *h, const char *filename, int flags)
+@@ -642,8 +631,8 @@ static int android_content_open(URLContext *h, const char *filename, int flags)
      if (ret < 0)
          goto done;
  

--- a/patches/003-hls-delete.patch
+++ b/patches/003-hls-delete.patch
@@ -1,5 +1,5 @@
 diff --git a/libavformat/hlsenc.c b/libavformat/hlsenc.c
-index 081d91f..894854f 100644
+index 957b9a5..1d21f55 100644
 --- a/libavformat/hlsenc.c
 +++ b/libavformat/hlsenc.c
 @@ -26,6 +26,7 @@
@@ -9,8 +9,8 @@ index 081d91f..894854f 100644
 +#include "fio.h"
  #endif
  
- #include "libavutil/avassert.h"
-@@ -593,7 +594,7 @@ static int hls_delete_file(HLSContext *hls, AVFormatContext *avf,
+ #include "libavutil/attributes_internal.h"
+@@ -519,7 +520,7 @@ static int hls_delete_file(HLSContext *hls, AVFormatContext *avf,
  
          //Nothing to write
          hlsenc_io_close(avf, &hls->http_delete, path);

--- a/patches/004-mkdir.patch
+++ b/patches/004-mkdir.patch
@@ -1,16 +1,16 @@
 diff --git a/libavformat/utils.c b/libavformat/utils.c
-index e892e8b..81a08a7 100644
+index 7a74e63..787cb9f 100644
 --- a/libavformat/utils.c
 +++ b/libavformat/utils.c
-@@ -38,6 +38,7 @@
+@@ -44,6 +44,7 @@
  #include "network.h"
  #endif
  #include "os_support.h"
 +#include "fio.h"
+ #include "urldecode.h"
  
  /**
-  * @file
-@@ -432,13 +433,13 @@ int ff_mkdir_p(const char *path)
+@@ -442,13 +443,13 @@ int ff_mkdir_p(const char *path)
          if (*pos == '/' || *pos == '\\') {
              tmp_ch = *pos;
              *pos = '\0';

--- a/scripts/build-ffmpeg.sh
+++ b/scripts/build-ffmpeg.sh
@@ -141,7 +141,7 @@ if [ "$MINIMAL" -eq 1 ]; then
         --enable-protocol=file \
         --enable-protocol=pipe \
         --enable-demuxer=rawvideo,image2,matroska,mov,mpegts,lavfi \
-        --enable-muxer=rawvideo,image2,matroska,mpegts,hls,null \
+        --enable-muxer=rawvideo,image2,matroska,mpegts,mp4,hls,null \
         --enable-decoder=rawvideo,wrapped_avframe \
         --enable-encoder=rawvideo,wrapped_avframe \
         --enable-parser=h264,hevc \


### PR DESCRIPTION
Upgrades our patches for the underlying jellyfin-ffmpeg on their newly merged ffmpeg 8.1 support

Need to figure out how to (or whether to) support the 7.x clients